### PR TITLE
Bug/cpuvalidmax

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 ## Release History
 
+### Version Next
+
+* aws.ecs.cpuutilization metrics should not have a validMax for Service resources
+
 ### Version 1.3.0
 
 * Adjusted build to use metricly-cli for validation

--- a/analyticConfigurations/metric_meta-aws.ecs.service.json
+++ b/analyticConfigurations/metric_meta-aws.ecs.service.json
@@ -2,16 +2,7 @@
   "analyticConfiguration": {
     "metrics": [
       {
-        "match": "^aws\\.ecs\\.memory.*",
-        "properties": {
-          "tags": {
-            "unit": "percent"
-          },
-          "validMax": 100
-        }
-      },
-      {
-        "match": "^aws\\.ecs\\.cpu.*",
+        "match": "^aws\\.ecs\\.(cpu|memory).*",
         "properties": {
           "tags": {
             "unit": "percent"

--- a/analyticConfigurations/metric_meta-aws.ecs.service.json
+++ b/analyticConfigurations/metric_meta-aws.ecs.service.json
@@ -2,12 +2,20 @@
   "analyticConfiguration": {
     "metrics": [
       {
-        "match": "^aws\\.ecs\\.(cpu.*|memory.*)",
+        "match": "^aws\\.ecs\\.memory.*",
         "properties": {
           "tags": {
             "unit": "percent"
           },
           "validMax": 100
+        }
+      },
+      {
+        "match": "^aws\\.ecs\\.cpu.*",
+        "properties": {
+          "tags": {
+            "unit": "percent"
+          }
         }
       },
       {


### PR DESCRIPTION
CPUutil will not be normalized at the service level. So we shouldn't set a valid max for CPU util here. Otherwise rollup data will have blanks.